### PR TITLE
feat: separate label filtering for issues and epics

### DIFF
--- a/src/components/EpicCreator.tsx
+++ b/src/components/EpicCreator.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import gitlabService from '../services/gitlabService';
-import { useLabelStore } from '../store/useLabelStore';
+import { useLabelStore, filterLabelsByKeywords } from '../store/useLabelStore';
 import { useEpicStore } from '../store/useEpicStore';
-import { useGeneratedEpicStore } from '../store/useGeneratedEpicStore';
 import debounce from 'lodash.debounce';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -20,25 +19,21 @@ import { Checkbox } from './ui/checkbox';
 
 
 const EpicCreator = () => {
-  const { labels, setLabels } = useLabelStore();
+  const { labels, setLabels, epicKeywords } = useLabelStore();
   const { selectedEpic: parentEpic, setEpic: setParentEpic } = useEpicStore();
-  const { generatedContent, updateField, clearContent } = useGeneratedEpicStore();
 
-  // Use generated content from store or fallback to empty values
-  const titlePrefix = generatedContent?.titlePrefix || '';
-  const title = generatedContent?.title || '';
-  const description = generatedContent?.description || '';
-  const selectedLabels = generatedContent?.selectedLabels || [];
-  const prompt = generatedContent?.prompt || '';
-  const enableEpic = generatedContent?.enableEpic || false;
-  const storedParentEpic = generatedContent?.parentEpic;
-
+  const [titlePrefix, setTitlePrefix] = useState('');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
   const [parentQuery, setParentQuery] = useState('');
   const [parentResults, setParentResults] = useState<{ id: number; title: string; web_url: string }[]>([]);
   const [searching, setSearching] = useState(false);
   const [loading, setLoading] = useState(false);
   const [createdEpic, setCreatedEpic] = useState<{ iid: number; url: string } | null>(null);
   const [message, setMessage] = useState<string | null>(null);
+  const [prompt, setPrompt] = useState('');
+  const [enableEpic, setEnableEpic] = useState(false);
   const { aiBackend, groupId } = useSettingsStore();
   const { prefixes } = usePrefixStore();
 
@@ -81,10 +76,9 @@ const EpicCreator = () => {
   }, [parentQuery, debouncedSearch]);
 
   const toggleLabel = (name: string) => {
-    const newLabels = selectedLabels.includes(name)
-      ? selectedLabels.filter(l => l !== name)
-      : [...selectedLabels, name];
-    updateField('selectedLabels', newLabels);
+    setSelectedLabels(prev =>
+      prev.includes(name) ? prev.filter(l => l !== name) : [...prev, name],
+    );
   };
 
   const handleGenerate = async () => {
@@ -94,8 +88,8 @@ const EpicCreator = () => {
     try {
       const res = await generateEpic(prompt, aiBackend);
       const { title: aiTitle, description: aiDesc } = res;
-      updateField('title', aiTitle);
-      updateField('description', aiDesc);
+      setTitle(aiTitle);
+      setDescription(aiDesc);
     } catch (e: any) {
       setMessage(e.message || 'Failed to generate');
     } finally {
@@ -116,12 +110,9 @@ const EpicCreator = () => {
     setMessage(null);
     try {
       const fullTitle = titlePrefix ? `${titlePrefix} ${title}` : title;
-      const epicToUse = storedParentEpic || parentEpic;
-      const res = await gitlabService.createEpic(groupId, fullTitle, description, selectedLabels, epicToUse?.id, enableEpic);
+      const res = await gitlabService.createEpic(groupId, fullTitle, description, selectedLabels, parentEpic?.id,enableEpic);
       setMessage(`Epic created: ${res.web_url}`);
-      setCreatedEpic({ iid: res.iid, url: res.web_url });
-      // Clear the generated content after successful creation
-      clearContent();
+    setCreatedEpic({ iid: res.iid, url: res.web_url });
     } catch (e: any) {
       setMessage(e.message || 'Failed to create epic');
     } finally {
@@ -131,63 +122,63 @@ const EpicCreator = () => {
 
   return (
     <div className="grid md:grid-cols-2 gap-6">
-      <div className="max-w-3xl flex flex-col gap-6">
+     <div className="max-w-3xl flex flex-col gap-6">
 
 
-        <div>
-          <Label>Prompt</Label>
-          <Textarea
-            rows={3}
-            value={prompt}
-            onChange={e => updateField('prompt', e.target.value)}
-          />
-          <Button
-            className="mt-2"
-            variant="primary"
-            size="sm"
-            loading={loading}
-            onClick={handleGenerate}
-          >
-            Generate with AI
-          </Button>
-        </div>
+      <div>
+        <Label>Prompt</Label>
+        <Textarea
+          rows={3}
+          value={prompt}
+          onChange={e => setPrompt(e.target.value)}
+        />
+        <Button
+          className="mt-2"
+          variant="primary"
+          size="sm"
+          loading={loading}
+          onClick={handleGenerate}
+        >
+          Generate with AI
+        </Button>
+      </div>
 
-        <div>
-          <Label>Title Prefix</Label>
-          <Select
-            value={titlePrefix}
-            onChange={e => updateField('titlePrefix', e.target.value)}
-          >
-            <option value="">Select prefix</option>
-            {prefixes.map(p => (
-              <option key={p} value={p}>
-                {p}
-              </option>
-            ))}
-          </Select>
-        </div>
+      <div>
+        <Label>Title Prefix</Label>
+        <Select
+          value={titlePrefix}
+          onChange={e => setTitlePrefix(e.target.value)}
+        >
+          <option value="">Select prefix</option>
+          {prefixes.map(p => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </Select>
+      </div>
 
-        <div>
-          <Label required>Title</Label>
-          <Input
-            value={title}
-            onChange={e => updateField('title', e.target.value)}
-          />
-        </div>
+      <div>
+        <Label required>Title</Label>
+        <Input
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+        />
+      </div>
 
-        <div>
-          <Label>Description</Label>
-          <Textarea
-            rows={6}
-            value={description}
-            onChange={e => updateField('description', e.target.value)}
-          />
-        </div>
+      <div>
+        <Label>Description</Label>
+        <Textarea
+          rows={6}
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+        />
+      </div>
 
-        <div>
-          <Label>Labels</Label>
-          <div className="flex flex-wrap gap-2 max-h-32 overflow-y-auto border p-2 rounded-md">
-            {labels.map(l => (
+      <div>
+        <Label>Labels</Label>
+        <div className="flex flex-wrap gap-2 max-h-32 overflow-y-auto border p-2 rounded-md">
+          {filterLabelsByKeywords(labels, epicKeywords).map(l => (
               <Checkbox
                 key={l.name}
                 label={l.name}
@@ -196,73 +187,72 @@ const EpicCreator = () => {
                 size="sm"
               />
             ))}
-          </div>
         </div>
+      </div>
 
-        <Checkbox
-          label="Link Epic"
-          checked={enableEpic}
-          onChange={e => updateField('enableEpic', e.target.checked)}
+      <Checkbox
+        label="Link Epic"
+        checked={enableEpic}
+        onChange={e => setEnableEpic(e.target.checked)}
+      />
+          
+{enableEpic && (      <div>
+        <Label>Parent Epic (optional)</Label>
+        <Input
+          placeholder="Search parent epic by title..."
+          value={parentQuery}
+          onChange={e => setParentQuery(e.target.value)}
         />
-
-        {enableEpic && (<div>
-          <Label>Parent Epic (optional)</Label>
-          <Input
-            placeholder="Search parent epic by title..."
-            value={parentQuery}
-            onChange={e => setParentQuery(e.target.value)}
-          />
-          {searching && <p className="text-sm">Searching...</p>}
-          {parentResults.length > 0 && (
-            <div className="border border-border max-h-48 overflow-y-auto rounded-md bg-popover mt-1">
-              {parentResults.map(ep => (
-                <div
-                  key={ep.id}
-                  className="px-2 py-1 hover:bg-accent hover:text-accent-foreground cursor-pointer text-sm"
-                  onClick={() => {
-                    setParentEpic(ep);
-                    updateField('parentEpic', ep);
-                    setParentQuery(ep.title);
-                    setParentResults([]);
-                  }}
-                >
-                  {ep.title}
-                </div>
-              ))}
-            </div>
-          )}
-          {(storedParentEpic || parentEpic) && <p className="text-sm mt-1 text-app-semantic-success">Selected: {(storedParentEpic || parentEpic)?.title}</p>}
-        </div>)}
-
-        {createdEpic ? (
-          <a
-            href={createdEpic.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={cn(buttonVariants({ variant: "success" }))}
-          >
-            Epic #{createdEpic.iid} created
-          </a>
-        ) : (
-          <Button
-            variant="primary"
-            size="md"
-            loading={loading}
-            onClick={handleCreateEpic}
-          >
-            Create Epic
-          </Button>
+        {searching && <p className="text-sm">Searching...</p>}
+        {parentResults.length > 0 && (
+          <div className="border border-border max-h-48 overflow-y-auto rounded-md bg-popover mt-1">
+            {parentResults.map(ep => (
+              <div
+                key={ep.id}
+                className="px-2 py-1 hover:bg-accent hover:text-accent-foreground cursor-pointer text-sm"
+                onClick={() => {
+                  setParentEpic(ep);
+                  setParentQuery(ep.title);
+                  setParentResults([]);
+                }}
+              >
+                {ep.title}
+              </div>
+            ))}
+          </div>
         )}
+        {parentEpic && <p className="text-sm mt-1 text-app-semantic-success">Selected: {parentEpic.title}</p>}
+      </div>)}
 
-        {message && <p className="mt-2 text-sm">{message}</p>}
-      </div>
-      <div className="max-w-3xl mx-auto flex flex-col gap-6">
-        <h2 className="text-lg font-medium">Preview</h2>
+      {createdEpic ? (
+        <a
+          href={createdEpic.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(buttonVariants({ variant: "success" }))}
+        >
+          Epic #{createdEpic.iid} created
+        </a>
+      ) : (
+        <Button
+          variant="primary"
+          size="md"
+          loading={loading}
+          onClick={handleCreateEpic}
+        >
+          Create Epic
+        </Button>
+      )}
 
-        <h1>{titlePrefix ? `${titlePrefix} ${title}` : title}</h1>
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{description}</ReactMarkdown>
+      {message && <p className="mt-2 text-sm">{message}</p>}
       </div>
+    <div className="max-w-3xl mx-auto flex flex-col gap-6">
+    <h2 className="text-lg font-medium">Preview</h2>
+
+    <h1>{titlePrefix ? `${titlePrefix} ${title}` : title}</h1>
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{description}</ReactMarkdown>
     </div>
+  </div>
   );
 };
 

--- a/src/components/settings/LabelsSettings.tsx
+++ b/src/components/settings/LabelsSettings.tsx
@@ -1,18 +1,21 @@
 import { useState } from "react";
 import gitlabService from "../../services/gitlabService";
-import { useLabelStore } from "../../store/useLabelStore";
+import { useLabelStore, filterLabelsByKeywords } from "../../store/useLabelStore";
 import { useSettingsStore } from "../../store/useSettingsStore";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 
 const LabelsSettings = () => {
-  const { labels, setLabels, keywords, setKeywords } = useLabelStore();
-  const [preview, setPreview] = useState<typeof labels>([]);
+  const { labels, setLabels, issueKeywords, epicKeywords, setIssueKeywords, setEpicKeywords } = useLabelStore();
+  const [allLabels, setAllLabels] = useState<typeof labels>([]);
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
 
   const projectId = useSettingsStore.getState().projectId;
+
+  const issuePreview = filterLabelsByKeywords(allLabels, issueKeywords);
+  const epicPreview = filterLabelsByKeywords(allLabels, epicKeywords);
 
   const handleFetch = async () => {
     if (!projectId) {
@@ -23,9 +26,9 @@ const LabelsSettings = () => {
     setMessage(null);
     try {
       const all = await gitlabService.fetchLabels(projectId);
-      const filtered = filterLabels(all, keywords);
-      setPreview(filtered);
-    } catch (err: unknown) {
+      setAllLabels(all);
+      setMessage(`Fetched ${all.length} labels. Set filter keywords to preview filtered results.`);
+    } catch (err: any) {
       setMessage(err.message || "Failed to fetch labels");
     } finally {
       setLoading(false);
@@ -33,64 +36,112 @@ const LabelsSettings = () => {
   };
 
   const handleSave = () => {
-    setLabels(preview);
-    setMessage("Saved!");
+    if (allLabels.length === 0) {
+      setMessage("Please fetch labels first");
+      return;
+    }
+    
+    setLabels(allLabels);
+    setMessage("Label filters saved!");
   };
 
   return (
-    <div className="max-w-xl">
+    <div className="max-w-2xl">
       <h2 className="text-xl font-semibold mb-4">Label Settings</h2>
 
-      <Label>Filter Keywords (comma separated)</Label>
-      <Input
-        value={keywords}
-        onChange={(e) => setKeywords(e.target.value)}
-        placeholder="bug,frontend,urgent"
-        className="mb-4"
-      />
-
-      <Button
-        onClick={handleFetch}
-        variant="primary"
-        className="mr-2"
-        disabled={loading}
-        loading={loading}
-      >
-        Fetch & Preview
-      </Button>
-      <Button
-        onClick={handleSave}
-        variant="primary"
-        disabled={preview.length === 0}
-      >
-        Save
-      </Button>
-
-      {preview.length > 0 && (
-        <div className="mt-4 max-h-64 overflow-y-auto border p-2 rounded-md">
-          {preview.map((l) => (
-            <div key={l.id} className="text-sm py-0.5">
-              {l.name}
+      {allLabels.length > 0 && (
+        <div className="mb-6">
+          <h3 className="text-sm font-medium mb-2">All Available Labels ({allLabels.length})</h3>
+          <div className="max-h-32 overflow-y-auto border p-2 rounded-md bg-gray-50">
+            <div className="flex flex-wrap gap-1">
+              {allLabels.map((l) => (
+                <span key={l.id} className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded">
+                  {l.name}
+                </span>
+              ))}
             </div>
-          ))}
+          </div>
         </div>
       )}
+
+      <div className="grid md:grid-cols-2 gap-6">
+        <div>
+          <Label>Issue Filter Keywords (comma separated)</Label>
+          <Input
+            value={issueKeywords}
+            onChange={(e) => setIssueKeywords(e.target.value)}
+            placeholder="bug,frontend,urgent"
+            className="mb-4"
+          />
+          
+          {allLabels.length > 0 && (
+            <div>
+              <h3 className="text-sm font-medium mb-2">
+                Issue Labels Preview ({issuePreview.length})
+                {issueKeywords.trim() === '' && <span className="text-gray-500 font-normal"> - showing all</span>}
+              </h3>
+              <div className="max-h-48 overflow-y-auto border p-2 rounded-md">
+                {issuePreview.map((l) => (
+                  <div key={l.id} className="text-sm py-0.5">
+                    {l.name}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div>
+          <Label>Epic Filter Keywords (comma separated)</Label>
+          <Input
+            value={epicKeywords}
+            onChange={(e) => setEpicKeywords(e.target.value)}
+            placeholder="epic,feature,milestone"
+            className="mb-4"
+          />
+          
+          {allLabels.length > 0 && (
+            <div>
+              <h3 className="text-sm font-medium mb-2">
+                Epic Labels Preview ({epicPreview.length})
+                {epicKeywords.trim() === '' && <span className="text-gray-500 font-normal"> - showing all</span>}
+              </h3>
+              <div className="max-h-48 overflow-y-auto border p-2 rounded-md">
+                {epicPreview.map((l) => (
+                  <div key={l.id} className="text-sm py-0.5">
+                    {l.name}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <Button
+          onClick={handleFetch}
+          variant="primary"
+          className="mr-2"
+          disabled={loading}
+          loading={loading}
+        >
+          Fetch & Preview
+        </Button>
+        <Button
+          onClick={handleSave}
+          variant="primary"
+          disabled={allLabels.length === 0}
+        >
+          Save
+        </Button>
+      </div>
 
       {message && <p className="mt-2 text-sm">{message}</p>}
     </div>
   );
 };
 
-import type { Label as LabelType } from "../../store/useLabelStore";
 
-function filterLabels(all: LabelType[], kw: string): LabelType[] {
-  if (!kw.trim()) return all;
-  const kws = kw
-    .toLowerCase()
-    .split(",")
-    .map((k) => k.trim())
-    .filter(Boolean);
-  return all.filter((l) => kws.some((k) => l.name.toLowerCase().includes(k)));
-}
 
 export default LabelsSettings;

--- a/src/store/useLabelStore.ts
+++ b/src/store/useLabelStore.ts
@@ -9,21 +9,31 @@ export interface Label {
 
 interface LabelState {
   labels: Label[];
-  keywords: string;
+  issueKeywords: string;
+  epicKeywords: string;
   setLabels: (labels: Label[]) => void;
-  setKeywords: (kw: string) => void;
+  setIssueKeywords: (kw: string) => void;
+  setEpicKeywords: (kw: string) => void;
 }
 
 export const useLabelStore = create<LabelState>()(
   persist(
     (set) => ({
       labels: [],
-      keywords: '',
+      issueKeywords: '',
+      epicKeywords: '',
       setLabels: (labels) => set({ labels }),
-      setKeywords: (keywords) => set({ keywords }),
+      setIssueKeywords: (issueKeywords) => set({ issueKeywords }),
+      setEpicKeywords: (epicKeywords) => set({ epicKeywords }),
     }),
     {
       name: 'label-store',
     },
   ),
 );
+
+export const filterLabelsByKeywords = (labels: Label[], keywords: string): Label[] => {
+  if (!keywords.trim()) return labels;
+  const kws = keywords.toLowerCase().split(',').map(k => k.trim()).filter(Boolean);
+  return labels.filter(l => kws.some(k => l.name.toLowerCase().includes(k)));
+};


### PR DESCRIPTION
Problem
Label filtering didn't work properly for epics. Users could only set one filter that applied to both issues and epics, and epic creation wasn't applying any filtering at all.

Solution
Split label filtering into separate issueKeywords and epicKeywords
Updated label settings UI to show all available labels first, then separate previews for each filter
Fixed epic creation to actually apply label filtering
Added real-time preview updates when typing filter keywords
Changes
Label Store: Added separate keyword fields and helper function
LabelsSettings: Improved UX - fetch shows all labels, then filter previews update as you type
EpicCreator: Now applies epic label filtering (was showing all labels before)
IssueGenerator: Uses issue-specific keywords instead of shared keywords