### PR TITLE
Fix checkbox click area accessibility issue

### DIFF
--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -12,7 +12,7 @@ const checkboxVariants = cva(
       },
       size: {
         sm: "h-3 w-3",
-        md: "h-4 w-4", 
+        md: "h-4 w-4",
         lg: "h-5 w-5",
       },
     },
@@ -25,7 +25,7 @@ const checkboxVariants = cva(
 
 export interface CheckboxProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size" | "type">,
-    VariantProps<typeof checkboxVariants> {
+  VariantProps<typeof checkboxVariants> {
   error?: boolean
   indeterminate?: boolean
   label?: string
@@ -33,22 +33,22 @@ export interface CheckboxProps
 }
 
 const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ 
-    className, 
-    variant, 
-    size, 
-    error, 
-    indeterminate, 
-    label, 
-    helperText, 
-    checked, 
+  ({
+    className,
+    variant,
+    size,
+    error,
+    indeterminate,
+    label,
+    helperText,
+    checked,
     id,
-    ...props 
+    ...props
   }, ref) => {
     const checkboxRef = React.useRef<HTMLInputElement>(null)
     const generatedId = React.useId()
     const inputId = id || generatedId
-    
+
     // Handle indeterminate state
     React.useEffect(() => {
       const checkbox = checkboxRef.current
@@ -59,7 +59,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
 
     // Determine the data-state for styling
     const dataState = indeterminate ? "indeterminate" : checked ? "checked" : "unchecked"
-    
+
     const checkboxVariant = error ? "error" : variant
 
     const CheckboxInput = (
@@ -79,7 +79,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
           id={inputId}
           className={cn(
             checkboxVariants({ variant: checkboxVariant, size }),
-            "sr-only",
+            "absolute inset-0 opacity-0 cursor-pointer",
             className
           )}
           data-state={dataState}
@@ -88,14 +88,14 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
             if (e.key === ' ' || e.key === 'Enter') {
               e.preventDefault()
               if (!props.disabled) {
-                checkboxRef.current?.click()
+                e.currentTarget.click()
               }
             }
             props.onKeyDown?.(e)
           }}
           {...props}
         />
-        <div 
+        <div
           className={cn(
             checkboxVariants({ variant: checkboxVariant, size }),
             "flex items-center justify-center cursor-pointer",
@@ -105,9 +105,15 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
             error && indeterminate && "bg-destructive text-destructive-foreground",
             props.disabled && "cursor-not-allowed"
           )}
-          onClick={() => {
+          onClick={(e) => {
             if (!props.disabled) {
-              checkboxRef.current?.click()
+              e.preventDefault()
+              e.stopPropagation()
+              const checkbox = checkboxRef.current
+              if (checkbox) {
+                checkbox.click()
+                checkbox.focus()
+              }
             }
           }}
         >
@@ -117,7 +123,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
               viewBox="0 0 16 16"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/>
+              <path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z" />
             </svg>
           )}
           {indeterminate && (
@@ -126,7 +132,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
               viewBox="0 0 16 16"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <path d="M4 8a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7A.5.5 0 0 1 4 8z"/>
+              <path d="M4 8a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7A.5.5 0 0 1 4 8z" />
             </svg>
           )}
         </div>
@@ -136,7 +142,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
     if (label) {
       return (
         <div className="space-y-1">
-          <label 
+          <label
             htmlFor={inputId}
             className="flex items-center gap-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
           >


### PR DESCRIPTION
Problem: 
Users could only interact with checkboxes by clicking on the label text. Clicking directly on the checkbox box itself didn't work, leading to poor user experience and accessibility issues.
Solution:
Fix checkbox click area accessibility issue

Replace sr-only with absolute inset-0 opacity-0 to make checkbox input clickable across entire area
Improve click event handling with proper preventDefault and focus management
Users can now click directly on checkbox box, not just label text
Maintains keyboard navigation and screen reader compatibility